### PR TITLE
npm start also builds the polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ Clone this repo and then change directories into webxr-polyfill/
 <a href="https://docs.npmjs.com/getting-started/installing-node">Install npm</a> and then run the following:
 
 	npm install   # downloads webpack and an http server
-	npm run build # creates dist/webxr-polyfill.js for browsers that can't load ES modules
-	npm run start # start the http server in the current directory
+	npm start     # builds the polyfill in dist/webxr-polyfill.js and start the http server in the current directory
+
+## Builds
+
+  npm run build # builds the polyfill in dist/webxr-polyfill.js
 
 Using one of the supported browsers listed below, go to http://YOUR_HOST_NAME:8080/
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "start": "http-server .",
+    "start": "npm run build && http-server .",
     "build": "webpack"
   },
   "repository": {


### PR DESCRIPTION
to simplify running the examples