### PR TITLE
Fix ARCore/Desktop low render resolution on page load.

### DIFF
--- a/polyfill/display/FlatDisplay.js
+++ b/polyfill/display/FlatDisplay.js
@@ -95,6 +95,8 @@ export default class FlatDisplay extends XRDisplay {
 		baseLayer._context.canvas.style.height = "100%";
 		baseLayer._context.canvas.width = this._xr._sessionEls.clientWidth;
 		baseLayer._context.canvas.height = this._xr._sessionEls.clientHeight;
+		baseLayer.framebufferWidth = this._xr._sessionEls.clientWidth;
+		baseLayer.framebufferHeight = this._xr._sessionEls.clientHeight;
 
 		if (this._arKitWrapper === null) {
 			// TODO:  Need to remove this listener if a new base layer is set


### PR DESCRIPTION
Fix ARCore/Desktop bug where the canvas has the default 300x150 dimensions on page load until a window resize event is triggered.