### PR TITLE
put current timestamps in the presentation frame

### DIFF
--- a/polyfill/XRPresentationFrame.js
+++ b/polyfill/XRPresentationFrame.js
@@ -5,9 +5,9 @@ import MatrixMath from './fill/MatrixMath.js'
 XRPresentationFrame provides all of the values needed to render a single frame of an XR scene to the XRDisplay.
 */
 export default class XRPresentationFrame {
-	constructor(session){
+	constructor(session, timestamp){
 		this._session = session
-		this._timestamp = this._session.reality._getTimeStamp();
+		this._timestamp = this._session.reality._getTimeStamp(timestamp);
 	}
 
 	get session(){ return this._session }

--- a/polyfill/XRSession.js
+++ b/polyfill/XRSession.js
@@ -59,13 +59,13 @@ export default class XRSession extends EventHandlerBase {
 	}
 
     _handleRequestFrame(callback) {
-		return this._display._requestAnimationFrame(() => {
+		return this._display._requestAnimationFrame((timestamp) => {
 			if (this._skip) {
 				this._skip = false;
 				return this._handleRequestFrame(callback)
 			}
 			//this._skip = true;  // try skipping every second raf
-			const frame = this._createPresentationFrame()
+			const frame = this._createPresentationFrame(timestamp)
 			this._updateCameraAnchor(frame)
 
 			this._display._reality._handleNewFrame(frame)
@@ -177,8 +177,8 @@ export default class XRSession extends EventHandlerBase {
 		this._display._startVideoFrames();
 	}
 
-	_createPresentationFrame(){
-		return new XRPresentationFrame(this)
+	_createPresentationFrame(timestamp){
+		return new XRPresentationFrame(this, timestamp)
 	}
 
 	_getCoordinateSystem(...types){

--- a/polyfill/reality/CameraReality.js
+++ b/polyfill/reality/CameraReality.js
@@ -568,12 +568,13 @@ export default class CameraReality extends Reality {
 		}
 	}
 
-	_getTimeStamp() {
+	_getTimeStamp(timestamp) {
 		if(this._arKitWrapper !== null){
 			return this._arKitWrapper.timestamp;
 		}else{
 			// use performance.now()
-			return 	( performance || Date ).now();
+			//return 	( performance || Date ).now();
+			return timestamp
 		}
 	}
 	/*

--- a/polyfill/reality/VirtualReality.js
+++ b/polyfill/reality/VirtualReality.js
@@ -73,6 +73,9 @@ export default class VirtualReality extends Reality {
 		})
 	}
 
+	_getTimeStamp(timestamp) {
+		return timestamp
+	}
 
 
 }


### PR DESCRIPTION
Use the timestamp provided by rAF unless we're on ARKit, in which case use the timestamp of the ARKit data.